### PR TITLE
Only require Doctrine Cache

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -23,7 +23,7 @@
     },
     "require": {
         "php": ">=5.4.0",
-        "doctrine/common": "2.4.*"
+        "doctrine/cache": "~1.4"
     },
     "require-dev": {
         "phpunit/phpunit": "~4.6"


### PR DESCRIPTION
We were pulling in a bunch of extra Doctrine libraries we weren't using.

```
$ composer update
Loading composer repositories with package information
Updating dependencies (including require-dev)
  - Removing doctrine/annotations (v1.2.6)
  - Removing doctrine/common (v2.4.2)
  - Removing doctrine/inflector (v1.0.1)
  - Removing doctrine/collections (v1.3.0)
  - Removing doctrine/lexer (v1.0.1)
Writing lock file
Generating autoload files
```
